### PR TITLE
Add basic auth and consultation forms

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,16 @@
           <q-icon name="medical_services" size="md" class="q-mr-sm" />
           <h1 class="text-h5 q-my-none">專業護理服務計費系統</h1>
         </q-toolbar-title>
+        <q-space />
+        <template v-if="auth.currentUser">
+          <span class="q-mr-sm">您好，{{ auth.currentUser.name }}</span>
+          <q-btn flat dense label="登出" class="q-mr-sm" @click="auth.logout()" />
+        </template>
+        <template v-else>
+          <q-btn flat dense label="登入" class="q-mr-sm" @click="loginDialog = true" />
+          <q-btn dense color="secondary" label="註冊" class="q-mr-sm" @click="registerDialog = true" />
+        </template>
+        <q-btn flat dense label="諮詢" @click="consultDialog = true" />
       </q-toolbar>
     </q-header>
 
@@ -602,14 +612,48 @@
         </q-card-section>
       </q-card>
     </q-dialog>
-  
+
+    <!-- 登入對話框 -->
+    <q-dialog v-model="loginDialog">
+      <q-card style="min-width: 350px">
+        <q-card-section class="text-h6">登入</q-card-section>
+        <q-card-section>
+          <LoginForm @success="loginDialog = false" />
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+
+    <!-- 註冊對話框 -->
+    <q-dialog v-model="registerDialog">
+      <q-card style="min-width: 350px">
+        <q-card-section class="text-h6">註冊</q-card-section>
+        <q-card-section>
+          <RegisterForm @success="registerDialog = false" />
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+
+    <!-- 諮詢對話框 -->
+    <q-dialog v-model="consultDialog">
+      <q-card style="min-width: 350px">
+        <q-card-section class="text-h6">諮詢表單</q-card-section>
+        <q-card-section>
+          <ConsultationForm @success="consultDialog = false" />
+        </q-card-section>
+      </q-card>
+    </q-dialog>
 
   </q-layout>
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import { Pie } from 'vue-chartjs'
 import useCareService from './composables/useCareService'
+import LoginForm from './components/LoginForm.vue'
+import RegisterForm from './components/RegisterForm.vue'
+import ConsultationForm from './components/ConsultationForm.vue'
+import { useAuthStore } from './store/auth'
 
 const {
   particlesLoaded,
@@ -662,6 +706,11 @@ const {
   getItemIcon,
   getItemColor
 } = useCareService()
+
+const loginDialog = ref(false)
+const registerDialog = ref(false)
+const consultDialog = ref(false)
+const auth = useAuthStore()
 </script>
 
 <style scoped>

--- a/src/components/ConsultationForm.vue
+++ b/src/components/ConsultationForm.vue
@@ -1,0 +1,25 @@
+<script setup>
+import { ref } from 'vue'
+
+const name = ref('')
+const phone = ref('')
+const description = ref('')
+const submitted = ref(false)
+const emit = defineEmits(['success'])
+
+function submit() {
+  submitted.value = true
+  emit('success')
+  console.log('Consultation', { name: name.value, phone: phone.value, description: description.value })
+}
+</script>
+
+<template>
+  <q-form @submit.prevent="submit">
+    <q-input v-model="name" label="姓名" required class="q-mb-sm" />
+    <q-input v-model="phone" label="電話" required class="q-mb-sm" />
+    <q-input v-model="description" label="需求說明" type="textarea" autogrow required class="q-mb-sm" />
+    <q-btn type="submit" color="primary" label="送出" class="full-width" />
+    <div v-if="submitted" class="text-positive q-mt-sm">表單已提交！</div>
+  </q-form>
+</template>

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { ref } from 'vue'
+import { useAuthStore } from '../store/auth'
+
+const email = ref('')
+const password = ref('')
+const error = ref('')
+const auth = useAuthStore()
+const emit = defineEmits(['success'])
+
+function submit() {
+  error.value = ''
+  try {
+    auth.login(email.value, password.value)
+    emit('success')
+  } catch (e) {
+    error.value = e.message
+  }
+}
+</script>
+
+<template>
+  <q-form @submit.prevent="submit">
+    <q-input v-model="email" label="電子郵件" type="email" required class="q-mb-sm" />
+    <q-input v-model="password" label="密碼" type="password" required class="q-mb-sm" />
+    <div class="text-negative q-mb-sm">{{ error }}</div>
+    <q-btn type="submit" color="primary" label="登入" class="full-width" />
+    <div class="q-mt-sm text-right">
+      <q-btn flat size="sm" label="忘記密碼？" />
+    </div>
+  </q-form>
+</template>

--- a/src/components/RegisterForm.vue
+++ b/src/components/RegisterForm.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { ref } from 'vue'
+import { useAuthStore } from '../store/auth'
+
+const name = ref('')
+const email = ref('')
+const password = ref('')
+const confirmPassword = ref('')
+const error = ref('')
+const auth = useAuthStore()
+const emit = defineEmits(['success'])
+
+function submit() {
+  error.value = ''
+  if (password.value !== confirmPassword.value) {
+    error.value = '密碼不一致'
+    return
+  }
+  try {
+    auth.register(name.value, email.value, password.value)
+    emit('success')
+  } catch (e) {
+    error.value = e.message
+  }
+}
+</script>
+
+<template>
+  <q-form @submit.prevent="submit">
+    <q-input v-model="name" label="姓名" required class="q-mb-sm" />
+    <q-input v-model="email" label="電子郵件" type="email" required class="q-mb-sm" />
+    <q-input v-model="password" label="密碼" type="password" required class="q-mb-sm" />
+    <q-input v-model="confirmPassword" label="確認密碼" type="password" required class="q-mb-sm" />
+    <div class="text-negative q-mb-sm">{{ error }}</div>
+    <q-btn type="submit" color="primary" label="提交" class="full-width" />
+  </q-form>
+</template>

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -1,0 +1,32 @@
+import { defineStore } from 'pinia'
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    users: JSON.parse(localStorage.getItem('users') || '[]'),
+    currentUser: JSON.parse(localStorage.getItem('currentUser') || 'null')
+  }),
+  actions: {
+    register(name, email, password) {
+      if (this.users.find(u => u.email === email)) {
+        throw new Error('Email already exists')
+      }
+      const user = { name, email, password }
+      this.users.push(user)
+      localStorage.setItem('users', JSON.stringify(this.users))
+      this.currentUser = user
+      localStorage.setItem('currentUser', JSON.stringify(user))
+    },
+    login(email, password) {
+      const user = this.users.find(u => u.email === email && u.password === password)
+      if (!user) {
+        throw new Error('Invalid credentials')
+      }
+      this.currentUser = user
+      localStorage.setItem('currentUser', JSON.stringify(user))
+    },
+    logout() {
+      this.currentUser = null
+      localStorage.removeItem('currentUser')
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add registration, login and consultation form components
- wire up dialogs in `App.vue` to use the new forms
- store user credentials locally via new `auth` pinia store

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840fd33e48c8325974fc03caca68bfe