### PR TITLE
Add navigation and info pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,18 @@
 <template>
-  <q-layout view="lHh Lpr lFf">
+  <q-layout view="hHh Lpr lFf">
+    <q-header elevated>
+      <q-toolbar>
+        <q-btn flat to="/" label="首頁" />
+        <q-btn flat to="/services" label="服務介紹" />
+        <q-btn flat to="/caregivers" label="看護列表" />
+        <q-btn flat to="/pricing" label="計費" />
+        <q-btn flat to="/about" label="關於我們" />
+        <q-btn flat to="/subsidy" label="補助資訊" />
+        <q-btn flat to="/blog" label="常見問題" />
+        <q-btn flat to="/contact" label="聯繫我們" />
+      </q-toolbar>
+    </q-header>
+
     <q-page-container>
       <router-view />
     </q-page-container>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import Home from '../views/Home.vue'
 import Calculator from '../views/Calculator.vue'
 import CaregiverList from '../views/CaregiverList.vue'
 import CaregiverDetail from '../views/CaregiverDetail.vue'
@@ -17,9 +18,14 @@ import Payments from '../views/Payments.vue'
 import Reviews from '../views/Reviews.vue'
 import Match from '../views/Match.vue'
 import Search from '../views/Search.vue'
+import Subsidy from '../views/Subsidy.vue'
+import Blog from '../views/Blog.vue'
+import About from '../views/About.vue'
+import AppDownload from '../views/AppDownload.vue'
 
 const routes = [
-  { path: '/', name: 'calculator', component: Calculator },
+  { path: '/', name: 'home', component: Home },
+  { path: '/calculator', name: 'calculator', component: Calculator },
   { path: '/caregivers', name: 'caregivers', component: CaregiverList },
   { path: '/caregivers/:id', name: 'caregiver-detail', component: CaregiverDetail },
   { path: '/services', name: 'services', component: Services },
@@ -36,7 +42,11 @@ const routes = [
   { path: '/payments', name: 'payments', component: Payments },
   { path: '/reviews', name: 'reviews', component: Reviews },
   { path: '/match', name: 'match', component: Match },
-  { path: '/search', name: 'search', component: Search }
+  { path: '/search', name: 'search', component: Search },
+  { path: '/subsidy', name: 'subsidy', component: Subsidy },
+  { path: '/blog', name: 'blog', component: Blog },
+  { path: '/about', name: 'about', component: About },
+  { path: '/app', name: 'app-download', component: AppDownload }
 ]
 const router = createRouter({
   history: createWebHistory('/dogfriend/'),  // 添加基礎路徑

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="page">
+    <h2>關於我們</h2>
+    <p>介紹公司的成立背景、服務理念與專業團隊。</p>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.page {
+  padding: 1rem;
+}
+</style>

--- a/src/views/AppDownload.vue
+++ b/src/views/AppDownload.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="page">
+    <h2>下載行動 App</h2>
+    <p>掃描 QR Code 或前往商店下載，隨時掌握服務進度。</p>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.page {
+  padding: 1rem;
+}
+</style>

--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="page">
+    <h2>知識分享與常見問題</h2>
+    <p>我們將在此更新照護知識與FAQ，幫助您更了解服務。</p>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.page {
+  padding: 1rem;
+}
+</style>

--- a/src/views/Subsidy.vue
+++ b/src/views/Subsidy.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="page">
+    <h2>補助與保險資訊</h2>
+    <p>這裡整理政府補助與保險相關連結，方便雇主查詢。</p>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.page {
+  padding: 1rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- add navigation header to main layout
- add About, Blog, Subsidy and App Download placeholder pages
- update router to include new pages and use Home as the root route

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(failed to complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_b_68412030825c832583ba1ad227f9e8e5