### PR TITLE
Improve dashboard page

### DIFF
--- a/nuxt-app/pages/dashboard.vue
+++ b/nuxt-app/pages/dashboard.vue
@@ -1,14 +1,66 @@
 <template>
-  <q-page class="q-pa-md flex flex-center">
-    <q-card flat bordered class="info-card">
-      <q-card-section>
-        <div class="text-h6">用戶儀表板</div>
-        <p>在此查看個人資料與紀錄。</p>
-      </q-card-section>
-    </q-card>
+  <q-page class="q-pa-md">
+    <div v-if="currentUser">
+      <q-card flat bordered class="info-card q-mb-md">
+        <q-card-section>
+          <div class="text-h6">歡迎回來，{{ currentUser.name }}</div>
+          <div class="text-subtitle2">{{ currentUser.email }}</div>
+        </q-card-section>
+      </q-card>
+
+      <q-card flat bordered class="info-card q-mb-md">
+        <q-card-section>
+          <div class="text-h6">推薦看護員</div>
+          <div v-if="recommended">
+            {{ recommended.name }} - 評分：{{ recommended.rating }}
+          </div>
+          <div v-else>暫無推薦資料</div>
+        </q-card-section>
+      </q-card>
+
+      <q-card flat bordered class="info-card">
+        <q-card-section>
+          <div class="text-h6">即將到來的排程</div>
+          <q-list>
+            <q-item v-for="(item, i) in schedule" :key="i" dense>
+              <q-item-section>{{ item.date }}</q-item-section>
+              <q-item-section>{{ item.time }}</q-item-section>
+              <q-item-section>{{ item.caregiver }}</q-item-section>
+            </q-item>
+          </q-list>
+        </q-card-section>
+      </q-card>
+    </div>
+    <div v-else class="flex flex-center">
+      <q-card flat bordered class="info-card">
+        <q-card-section>
+          <div class="text-h6">尚未登入</div>
+          <p>請先登入以查看儀表板內容。</p>
+        </q-card-section>
+      </q-card>
+    </div>
   </q-page>
 </template>
 
 <script setup>
+import { computed, ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useAuthStore } from '~/stores/auth'
+import { useCaregiverStore } from '~/stores/caregivers'
+
+const authStore = useAuthStore()
+const { currentUser } = storeToRefs(authStore)
+
+const caregiverStore = useCaregiverStore()
+const { caregivers } = storeToRefs(caregiverStore)
+
+const recommended = computed(() => {
+  return caregivers.value.slice().sort((a, b) => b.rating - a.rating)[0]
+})
+
+const schedule = ref([
+  { date: '2024-06-20', time: '10:00', caregiver: '王小明' },
+  { date: '2024-06-22', time: '14:00', caregiver: '李小美' }
+])
 </script>
 

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -1,14 +1,67 @@
 <template>
-  <q-page class="q-pa-md flex flex-center">
-    <q-card flat bordered class="info-card">
-      <q-card-section>
-        <div class="text-h6">用戶儀表板</div>
-        <p>在此查看個人資料與紀錄。</p>
-      </q-card-section>
-    </q-card>
+  <q-page class="q-pa-md">
+    <div v-if="currentUser">
+      <q-card flat bordered class="info-card q-mb-md">
+        <q-card-section>
+          <div class="text-h6">歡迎回來，{{ currentUser.name }}</div>
+          <div class="text-subtitle2">{{ currentUser.email }}</div>
+        </q-card-section>
+      </q-card>
+
+      <q-card flat bordered class="info-card q-mb-md">
+        <q-card-section>
+          <div class="text-h6">推薦看護員</div>
+          <div v-if="recommended">
+            {{ recommended.name }} - 評分：{{ recommended.rating }}
+          </div>
+          <div v-else>暫無推薦資料</div>
+        </q-card-section>
+      </q-card>
+
+      <q-card flat bordered class="info-card">
+        <q-card-section>
+          <div class="text-h6">即將到來的排程</div>
+          <q-list>
+            <q-item v-for="(item, i) in schedule" :key="i" dense>
+              <q-item-section>{{ item.date }}</q-item-section>
+              <q-item-section>{{ item.time }}</q-item-section>
+              <q-item-section>{{ item.caregiver }}</q-item-section>
+            </q-item>
+          </q-list>
+        </q-card-section>
+      </q-card>
+    </div>
+    <div v-else class="flex flex-center">
+      <q-card flat bordered class="info-card">
+        <q-card-section>
+          <div class="text-h6">尚未登入</div>
+          <p>請先登入以查看儀表板內容。</p>
+        </q-card-section>
+      </q-card>
+    </div>
   </q-page>
 </template>
 
 <script setup>
+import { computed, ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useAuthStore } from '../store/auth'
+import { useCaregiverStore } from '../store/caregivers'
+
+const authStore = useAuthStore()
+const { currentUser } = storeToRefs(authStore)
+
+const caregiverStore = useCaregiverStore()
+const { caregivers } = storeToRefs(caregiverStore)
+
+const recommended = computed(() => {
+  return caregivers.value.slice().sort((a, b) => b.rating - a.rating)[0]
+})
+
+const schedule = ref([
+  { date: '2024-06-20', time: '10:00', caregiver: '王小明' },
+  { date: '2024-06-22', time: '14:00', caregiver: '李小美' }
+])
 </script>
+
 


### PR DESCRIPTION
## Summary
- enhance `/dashboard` for Quasar and Nuxt implementations
- show current user info, recommended caregiver, and upcoming schedules

## Testing
- `npm run build` *(fails: nuxt not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684c390cc7d08325874bcc97006a868e