### PR TITLE
Improve match page recommendations

### DIFF
--- a/nuxt-app/pages/match.vue
+++ b/nuxt-app/pages/match.vue
@@ -1,27 +1,39 @@
 <template>
-  <q-page class="q-pa-md flex flex-center">
-    <q-card flat bordered class="info-card">
-      <q-card-section>
-        <div class="text-h6">看護媒合推薦</div>
-        <p v-if="recommended">
-          根據評分推薦：{{ recommended.name }} ({{ recommended.rating }})
-        </p>
-        <p v-else>暫無推薦資料</p>
-      </q-card-section>
-    </q-card>
-  </q-page>
+<q-page class="q-pa-md">
+  <div class="text-h6 q-mb-md">看護媒合推薦</div>
+  <div v-if="recommended.length" class="caregiver-list">
+    <CaregiverCard
+      v-for="c in recommended"
+      :key="c.id"
+      :caregiver="c"
+    />
+  </div>
+  <div v-else>暫無推薦資料</div>
+</q-page>
 </template>
 
 <script setup>
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useCaregiverStore } from '../store/caregivers'
+import CaregiverCard from '../components/CaregiverCard.vue'
 
 const store = useCaregiverStore()
 const { caregivers } = storeToRefs(store)
 
 const recommended = computed(() => {
-  return caregivers.value.slice().sort((a, b) => b.rating - a.rating)[0]
+  return caregivers.value
+    .slice()
+    .sort((a, b) => b.rating - a.rating)
+    .slice(0, 3)
 })
 </script>
+
+<style scoped>
+.caregiver-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+</style>
 

--- a/src/pages/Match.vue
+++ b/src/pages/Match.vue
@@ -1,14 +1,14 @@
 <template>
-  <q-page class="q-pa-md flex flex-center">
-    <q-card flat bordered class="info-card">
-      <q-card-section>
-        <div class="text-h6">看護媒合推薦</div>
-        <p v-if="recommended">
-          根據評分推薦：{{ recommended.name }} ({{ recommended.rating }})
-        </p>
-        <p v-else>暫無推薦資料</p>
-      </q-card-section>
-    </q-card>
+  <q-page class="q-pa-md">
+    <div class="text-h6 q-mb-md">看護媒合推薦</div>
+    <div v-if="recommended.length" class="caregiver-list">
+      <CaregiverCard
+        v-for="c in recommended"
+        :key="c.id"
+        :caregiver="c"
+      />
+    </div>
+    <div v-else>暫無推薦資料</div>
   </q-page>
 </template>
 
@@ -16,12 +16,24 @@
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useCaregiverStore } from '../store/caregivers'
+import CaregiverCard from '../components/CaregiverCard.vue'
 
 const store = useCaregiverStore()
 const { caregivers } = storeToRefs(store)
 
 const recommended = computed(() => {
-  return caregivers.value.slice().sort((a, b) => b.rating - a.rating)[0]
+  return caregivers.value
+    .slice()
+    .sort((a, b) => b.rating - a.rating)
+    .slice(0, 3)
 })
 </script>
+
+<style scoped>
+.caregiver-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+</style>
 


### PR DESCRIPTION
## Summary
- enhance match page to show top rated caregivers
- use `CaregiverCard` component for recommended caregivers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684c39332b7c832599f66c46de545eee