### PR TITLE
Enhance payments page

### DIFF
--- a/src/pages/Payments.vue
+++ b/src/pages/Payments.vue
@@ -1,14 +1,33 @@
 <template>
-  <q-page class="q-pa-md flex flex-center">
+  <q-page class="q-pa-md">
     <q-card flat bordered class="info-card">
       <q-card-section>
         <div class="text-h6">支付紀錄</div>
-        <p>在此查看支付狀態與歷史。</p>
+        <q-table
+          :rows="payments"
+          :columns="columns"
+          row-key="id"
+          flat
+          bordered
+          class="q-mt-md"
+        />
       </q-card-section>
     </q-card>
   </q-page>
 </template>
 
 <script setup>
+import { storeToRefs } from 'pinia'
+import { usePaymentsStore } from '../store/payments'
+
+const store = usePaymentsStore()
+const { payments } = storeToRefs(store)
+
+const columns = [
+  { name: 'date', label: '日期', field: 'date' },
+  { name: 'amount', label: '金額', field: 'amount', align: 'right' },
+  { name: 'method', label: '方式', field: 'method' },
+  { name: 'status', label: '狀態', field: 'status' }
+]
 </script>
 

--- a/src/store/payments.js
+++ b/src/store/payments.js
@@ -1,0 +1,18 @@
+import { defineStore } from 'pinia'
+
+export const usePaymentsStore = defineStore('payments', {
+  state: () => ({
+    payments: [
+      { id: 1, date: '2024-05-01', amount: 1000, method: '信用卡', status: '已完成' },
+      { id: 2, date: '2024-05-15', amount: 800, method: '轉帳', status: '待處理' }
+    ]
+  }),
+  getters: {
+    getAll: (state) => state.payments
+  },
+  actions: {
+    addPayment(payment) {
+      this.payments.push(payment)
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- create payments store for mocked payment history
- display payments in table format on Payments page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684c393ada6883259b41d4c07bf31b0e