### PR TITLE
Improve pricing page layout

### DIFF
--- a/src/assets/global.scss
+++ b/src/assets/global.scss
@@ -8,3 +8,13 @@ body {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
 }
+
+.pricing-card {
+  transition: all 0.3s ease;
+  border-radius: 12px;
+}
+
+.pricing-card:hover {
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+}

--- a/src/pages/Pricing.vue
+++ b/src/pages/Pricing.vue
@@ -1,30 +1,33 @@
 <template>
   <q-page class="q-pa-md">
-    <q-card flat bordered class="info-card">
-      <q-card-section>
-        <div class="text-h6">價格資訊</div>
-        <q-table
-          :rows="plans"
-          :columns="columns"
-          flat
-          bordered
-          class="q-mt-md"
-        />
-      </q-card-section>
-    </q-card>
+    <div class="row q-col-gutter-md">
+      <div
+        v-for="plan in plans"
+        :key="plan.type"
+        class="col-12 col-md-6 col-lg-4"
+      >
+        <q-card flat bordered class="info-card pricing-card">
+          <q-card-section class="text-center">
+            <div class="text-h6 q-mb-xs">{{ plan.type }}</div>
+            <div class="text-h5 text-primary q-mb-sm">{{ plan.price }}</div>
+            <div>{{ plan.desc }}</div>
+          </q-card-section>
+          <q-separator />
+          <q-card-actions align="right">
+            <q-btn color="primary" label="立即預約" />
+          </q-card-actions>
+        </q-card>
+      </div>
+    </div>
   </q-page>
 </template>
 
 <script setup>
-const columns = [
-  { name: 'type', label: '方案', field: 'type' },
-  { name: 'price', label: '價格', field: 'price' },
-  { name: 'desc', label: '內容', field: 'desc' }
-]
 
 const plans = [
   { type: '按時付費', price: 'NT$300/時', desc: '彈性選擇看護時數' },
-  { type: '包班制', price: 'NT$6000/天', desc: '全天候專業照護' }
+  { type: '包班制', price: 'NT$6000/天', desc: '全天候專業照護' },
+  { type: '長期合約', price: '每月 NT$18,000 起', desc: '適合長期照護需求' }
 ]
 </script>
 


### PR DESCRIPTION
## Summary
- redesign pricing page to show cards
- add new long-term contract plan
- create pricing-card style in global stylesheet

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c3941331c8325af31516c02d6d35b