### PR TITLE
Improve register page

### DIFF
--- a/nuxt-app/pages/register.vue
+++ b/nuxt-app/pages/register.vue
@@ -1,14 +1,21 @@
 <template>
   <q-page class="q-pa-md flex flex-center">
-    <q-card flat bordered class="info-card">
+    <q-card flat bordered class="info-card" style="min-width:300px;max-width:400px;">
       <q-card-section>
-        <div class="text-h6">註冊</div>
-        <p>註冊頁面示例。</p>
+        <div class="text-h6 q-mb-sm">註冊</div>
+        <RegisterForm @success="onSuccess" />
       </q-card-section>
     </q-card>
   </q-page>
 </template>
 
 <script setup>
+import { useRouter } from 'vue-router'
+import RegisterForm from '../components/RegisterForm.vue'
+
+const router = useRouter()
+function onSuccess() {
+  router.push('/dashboard')
+}
 </script>
 

--- a/src/pages/Register.vue
+++ b/src/pages/Register.vue
@@ -1,14 +1,21 @@
 <template>
   <q-page class="q-pa-md flex flex-center">
-    <q-card flat bordered class="info-card">
+    <q-card flat bordered class="info-card" style="min-width:300px;max-width:400px;">
       <q-card-section>
-        <div class="text-h6">註冊</div>
-        <p>註冊頁面示例。</p>
+        <div class="text-h6 q-mb-sm">註冊</div>
+        <RegisterForm @success="onSuccess" />
       </q-card-section>
     </q-card>
   </q-page>
 </template>
 
 <script setup>
+import { useRouter } from 'vue-router'
+import RegisterForm from '../components/RegisterForm.vue'
+
+const router = useRouter()
+function onSuccess() {
+  router.push('/dashboard')
+}
 </script>
 


### PR DESCRIPTION
## Summary
- embed RegisterForm and success handler on register page
- same improvements for nuxt version of register page

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c394b5b2083258b5f14633519e9a8