### PR TITLE
Enhance Quasar plugin configuration

### DIFF
--- a/nuxt-app/plugins/quasar.ts
+++ b/nuxt-app/plugins/quasar.ts
@@ -1,16 +1,21 @@
-import { Quasar, Notify } from 'quasar'
+import { Quasar, Notify, Dialog, Loading } from 'quasar'
+import langZhTW from 'quasar/lang/zh-TW'
 import '@quasar/extras/material-icons/material-icons.css'
 import 'quasar/src/css/index.sass'
 
 export default defineNuxtPlugin(nuxtApp => {
   nuxtApp.vueApp.use(Quasar, {
-    plugins: { Notify },
+    plugins: { Notify, Dialog, Loading },
+    lang: langZhTW,
     config: {
       dark: 'auto',
       notify: {
         position: 'top-right',
         timeout: 2000,
         textColor: 'white'
+      },
+      loading: {
+        delay: 400
       }
     }
   })


### PR DESCRIPTION
## Summary
- add dialog, loading and zh-TW language support to Quasar plugin

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c39a23dc0832592fe60d538a59b1f