### PR TITLE
Add vue-i18n integration

### DIFF
--- a/nuxt-app/layouts/default.vue
+++ b/nuxt-app/layouts/default.vue
@@ -11,14 +11,18 @@
           @click="drawer = !drawer"
         />
         <div class="q-gutter-sm q-hidden-xs">
-          <q-btn flat to="/" label="首頁" />
-          <q-btn flat to="/services" label="服務介紹" />
-          <q-btn flat to="/caregivers" label="看護列表" />
-          <q-btn flat to="/pricing" label="計費" />
-          <q-btn flat to="/about" label="關於我們" />
-          <q-btn flat to="/subsidy" label="補助資訊" />
-          <q-btn flat to="/blog" label="常見問題" />
-          <q-btn flat to="/contact" label="聯繫我們" />
+          <q-btn flat to="/" :label="$t('nav.home')" />
+          <q-btn flat to="/services" :label="$t('nav.services')" />
+          <q-btn flat to="/caregivers" :label="$t('nav.caregivers')" />
+          <q-btn flat to="/pricing" :label="$t('nav.pricing')" />
+          <q-btn flat to="/about" :label="$t('nav.about')" />
+          <q-btn flat to="/subsidy" :label="$t('nav.subsidy')" />
+          <q-btn flat to="/blog" :label="$t('nav.blog')" />
+          <q-btn flat to="/contact" :label="$t('nav.contact')" />
+        </div>
+        <div class="q-ml-md">
+          <q-btn flat size="sm" @click="locale = 'zh'">中文</q-btn>
+          <q-btn flat size="sm" @click="locale = 'en'">EN</q-btn>
         </div>
       </q-toolbar>
     </q-header>
@@ -26,7 +30,7 @@
     <q-drawer v-model="drawer" side="left" overlay class="q-pa-md">
       <q-list>
         <q-item v-for="item in menuItems" :key="item.to" clickable v-ripple :to="item.to" @click="drawer = false">
-          <q-item-section>{{ item.label }}</q-item-section>
+          <q-item-section>{{ $t(`nav.${item.key}`) }}</q-item-section>
         </q-item>
       </q-list>
     </q-drawer>
@@ -39,16 +43,18 @@
 
 <script setup>
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 const drawer = ref(false)
+const { locale } = useI18n()
 const menuItems = [
-  { label: '首頁', to: '/' },
-  { label: '服務介紹', to: '/services' },
-  { label: '看護列表', to: '/caregivers' },
-  { label: '計費', to: '/pricing' },
-  { label: '關於我們', to: '/about' },
-  { label: '補助資訊', to: '/subsidy' },
-  { label: '常見問題', to: '/blog' },
-  { label: '聯繫我們', to: '/contact' }
+  { key: 'home', to: '/' },
+  { key: 'services', to: '/services' },
+  { key: 'caregivers', to: '/caregivers' },
+  { key: 'pricing', to: '/pricing' },
+  { key: 'about', to: '/about' },
+  { key: 'subsidy', to: '/subsidy' },
+  { key: 'blog', to: '/blog' },
+  { key: 'contact', to: '/contact' }
 ]
 </script>

--- a/nuxt-app/locales/en.json
+++ b/nuxt-app/locales/en.json
@@ -1,0 +1,16 @@
+{
+  "nav": {
+    "home": "Home",
+    "services": "Services",
+    "caregivers": "Caregivers",
+    "pricing": "Pricing",
+    "about": "About Us",
+    "subsidy": "Subsidy",
+    "blog": "FAQ",
+    "contact": "Contact Us"
+  },
+  "index": {
+    "ourServices": "Our Services",
+    "whyUs": "Why Choose Us"
+  }
+}

--- a/nuxt-app/locales/zh.json
+++ b/nuxt-app/locales/zh.json
@@ -1,0 +1,16 @@
+{
+  "nav": {
+    "home": "首頁",
+    "services": "服務介紹",
+    "caregivers": "看護列表",
+    "pricing": "計費",
+    "about": "關於我們",
+    "subsidy": "補助資訊",
+    "blog": "常見問題",
+    "contact": "聯繫我們"
+  },
+  "index": {
+    "ourServices": "我們的服務",
+    "whyUs": "為何選擇我們"
+  }
+}

--- a/nuxt-app/nuxt.config.ts
+++ b/nuxt-app/nuxt.config.ts
@@ -4,7 +4,8 @@ import { defineNuxtConfig } from 'nuxt/config'
 export default defineNuxtConfig({
   modules: [
     '@pinia/nuxt',
-    '@vite-pwa/nuxt'
+    '@vite-pwa/nuxt',
+    '@nuxtjs/i18n'
   ],
   css: [
     'quasar/src/css/index.sass',
@@ -24,6 +25,19 @@ export default defineNuxtConfig({
       short_name: 'CareCalc',
       description: 'Care service management and scheduling app',
       theme_color: '#ffffff'
+    }
+  },
+  i18n: {
+    langDir: 'locales',
+    locales: [
+      { code: 'en', file: 'en.json', name: 'English' },
+      { code: 'zh', file: 'zh.json', name: '中文' }
+    ],
+    defaultLocale: 'zh',
+    vueI18n: {
+      legacy: false,
+      locale: 'zh',
+      fallbackLocale: 'zh'
     }
   }
 })

--- a/nuxt-app/package.json
+++ b/nuxt-app/package.json
@@ -26,7 +26,8 @@
     "pinia": "^2.1.7",
     "nuxt": "^3.10.0",
     "@pinia/nuxt": "^0.5.8",
-    "@vite-pwa/nuxt": "^0.8.0"
+    "@vite-pwa/nuxt": "^0.8.0",
+    "@nuxtjs/i18n": "^8.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",

--- a/nuxt-app/pages/index.vue
+++ b/nuxt-app/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <q-page class="q-pa-md">
     <div class="q-mb-lg">
-      <h2 class="text-h5 q-mb-md">我們的服務</h2>
+      <h2 class="text-h5 q-mb-md">{{ $t('index.ourServices') }}</h2>
       <q-list bordered class="rounded-borders bg-white">
         <q-item>
           <q-item-section avatar>
@@ -34,7 +34,7 @@
     </div>
 
     <div>
-      <h2 class="text-h5 q-mb-md">為何選擇我們</h2>
+      <h2 class="text-h5 q-mb-md">{{ $t('index.whyUs') }}</h2>
       <q-card class="q-mb-sm" bordered>
         <q-card-section class="text-center">
           <div class="text-h6">快速媒合</div>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "pinia": "^2.1.7",
     "nuxt": "^3.10.0",
     "@pinia/nuxt": "^0.5.8",
-    "@vite-pwa/nuxt": "^0.8.0"
+    "@vite-pwa/nuxt": "^0.8.0",
+    "@nuxtjs/i18n": "^8.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",


### PR DESCRIPTION
## Summary
- enable `@nuxtjs/i18n` in Nuxt configuration
- provide English and Chinese translation files
- internationalize navigation and home page text
- add quick locale switch buttons
- declare vue-i18n dependency

## Testing
- `npm install` *(fails: 403 Forbidden – registry access blocked)*
- `npm run build` *(fails: `nuxt: not found` due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_684c4029f10c8325b5e7d1a265fdc4b9