### PR TITLE
Add Stylelint config

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,3 @@
+dist/
+.nuxt/
+node_modules/

--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['stylelint-config-standard-scss'],
+}

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Learn more about IDE Support for Vue in the [Vue Docs Scaling up Guide](https://
 
 ## Code Style
 
-This project uses ESLint and Prettier to keep the code style consistent.
+This project uses ESLint, Prettier and Stylelint to keep the code style consistent.
 
-- `npm run lint` runs ESLint.
+- `npm run lint` runs ESLint for JavaScript and Vue files.
+- `npm run lint:style` runs Stylelint for CSS/SCSS files.
 - `npm run format` formats files with Prettier.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",
     "lint": "eslint .",
+    "lint:style": "stylelint \"**/*.{css,scss,vue}\" --ignore-path .stylelintignore",
     "format": "prettier -w ."
   },
   "dependencies": {
@@ -39,6 +40,8 @@
     "eslint": "^8.57.0",
     "eslint-plugin-vue": "^9.20.0",
     "eslint-config-prettier": "^9.1.0",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
+    "stylelint": "^16.0.1",
+    "stylelint-config-standard-scss": "^11.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- document stylelint usage in README
- configure stylelint and ignore rules
- add lint:style script and stylelint packages

## Testing
- `npm run lint:style` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_684cb3298ed88325b1d54a0147c60b02