### PR TITLE
Fix caregiver store import paths

### DIFF
--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref } from 'vue'
-import { useAuthStore } from '../store/auth'
+import { useAuthStore } from '../stores/auth'
 
 const email = ref('')
 const password = ref('')

--- a/components/RegisterForm.vue
+++ b/components/RegisterForm.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref } from 'vue'
-import { useAuthStore } from '../store/auth'
+import { useAuthStore } from '../stores/auth'
 
 const name = ref('')
 const email = ref('')

--- a/pages/caregivers/[id].vue
+++ b/pages/caregivers/[id].vue
@@ -25,7 +25,7 @@
 
 <script setup>
 import { useRoute } from 'vue-router'
-import { useCaregiverStore } from '../store/caregivers'
+import { useCaregiverStore } from '../stores/caregivers'
 
 const route = useRoute()
 const store = useCaregiverStore()

--- a/pages/caregivers/index.vue
+++ b/pages/caregivers/index.vue
@@ -9,7 +9,7 @@
 <script setup>
 import { storeToRefs } from 'pinia'
 import CaregiverCard from '../components/CaregiverCard.vue'
-import { useCaregiverStore } from '../store/caregivers'
+import { useCaregiverStore } from '../stores/caregivers'
 
 const store = useCaregiverStore()
 const { caregivers } = storeToRefs(store)

--- a/pages/match.vue
+++ b/pages/match.vue
@@ -15,7 +15,7 @@
 <script setup>
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
-import { useCaregiverStore } from '../store/caregivers'
+import { useCaregiverStore } from '../stores/caregivers'
 import CaregiverCard from '../components/CaregiverCard.vue'
 
 const store = useCaregiverStore()

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -15,7 +15,7 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { storeToRefs } from 'pinia'
-import { useCaregiverStore } from '../store/caregivers'
+import { useCaregiverStore } from '../stores/caregivers'
 import CaregiverCard from '../components/CaregiverCard.vue'
 
 const store = useCaregiverStore()


### PR DESCRIPTION
## Summary
- fix incorrect imports of caregiver store and auth store across app

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run lint:style` *(fails: stylelint not found)*
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d647fff14832593f69230925fe587