### PR TITLE
Implement payments page

### DIFF
--- a/components/PaymentForm.vue
+++ b/components/PaymentForm.vue
@@ -1,0 +1,40 @@
+<script setup>
+import { ref } from 'vue'
+import { usePaymentsStore } from '../stores/payments'
+
+const date = ref('')
+const amount = ref(0)
+const method = ref('')
+const status = ref('')
+const store = usePaymentsStore()
+
+function submit() {
+  if (!date.value || !amount.value || !method.value || !status.value) return
+  store.addPayment({
+    id: Date.now(),
+    date: date.value,
+    amount: Number(amount.value),
+    method: method.value,
+    status: status.value
+  })
+  date.value = ''
+  amount.value = 0
+  method.value = ''
+  status.value = ''
+}
+</script>
+
+<template>
+  <q-form @submit.prevent="submit" class="q-mt-md">
+    <q-input v-model="date" label="日期" type="date" class="q-mb-sm" />
+    <q-input
+      v-model.number="amount"
+      label="金額"
+      type="number"
+      class="q-mb-sm"
+    />
+    <q-input v-model="method" label="付款方式" class="q-mb-sm" />
+    <q-input v-model="status" label="狀態" class="q-mb-sm" />
+    <q-btn type="submit" color="primary" label="新增紀錄" class="full-width" />
+  </q-form>
+</template>

--- a/pages/payments.vue
+++ b/pages/payments.vue
@@ -1,14 +1,33 @@
 <template>
-  <q-page class="q-pa-md flex flex-center">
+  <q-page class="q-pa-md">
     <q-card flat bordered class="info-card">
       <q-card-section>
         <div class="text-h6">支付紀錄</div>
         <p>在此查看支付狀態與歷史。</p>
+
+        <q-list bordered class="rounded-borders q-mt-md" v-if="payments.length">
+          <q-item v-for="p in payments" :key="p.id">
+            <q-item-section>{{ p.date }}</q-item-section>
+            <q-item-section>{{ p.amount }}</q-item-section>
+            <q-item-section>{{ p.method }}</q-item-section>
+            <q-item-section>{{ p.status }}</q-item-section>
+          </q-item>
+        </q-list>
+        <div v-else class="q-mt-md">尚無支付紀錄</div>
+
+        <q-separator spaced />
+        <PaymentForm />
       </q-card-section>
     </q-card>
   </q-page>
 </template>
 
 <script setup>
+import { storeToRefs } from 'pinia'
+import PaymentForm from '../components/PaymentForm.vue'
+import { usePaymentsStore } from '../stores/payments'
+
+const store = usePaymentsStore()
+const { payments } = storeToRefs(store)
 </script>
 

--- a/stores/payments.ts
+++ b/stores/payments.ts
@@ -2,10 +2,13 @@ import { defineStore } from 'pinia'
 
 export const usePaymentsStore = defineStore('payments', {
   state: () => ({
-    payments: [
-      { id: 1, date: '2024-05-01', amount: 1000, method: '信用卡', status: '已完成' },
-      { id: 2, date: '2024-05-15', amount: 800, method: '轉帳', status: '待處理' }
-    ]
+    payments: JSON.parse(
+      localStorage.getItem('payments') ||
+        JSON.stringify([
+          { id: 1, date: '2024-05-01', amount: 1000, method: '信用卡', status: '已完成' },
+          { id: 2, date: '2024-05-15', amount: 800, method: '轉帳', status: '待處理' }
+        ])
+    )
   }),
   getters: {
     getAll: (state) => state.payments
@@ -13,6 +16,7 @@ export const usePaymentsStore = defineStore('payments', {
   actions: {
     addPayment(payment) {
       this.payments.push(payment)
+      localStorage.setItem('payments', JSON.stringify(this.payments))
     }
   }
 })


### PR DESCRIPTION
## Summary
- add a form for adding payment data
- persist payments to localStorage
- list payments on the payments page

## Testing
- `npm run lint` *(fails: couldn't find config)*
- `npm run lint:style` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_687102f8966c83258c14544446dd966e