### PR TITLE
Enhance SEO defaults, remove binary assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ This project uses ESLint, Prettier and Stylelint to keep the code style consiste
 - `npm run lint:style` runs Stylelint for CSS/SCSS files.
 - `npm run format` formats files with Prettier.
 
+## SEO Enhancements
+
+The project now includes canonical and hreflang links, robots.txt, and automatic sitemap generation. The home page also provides basic JSON-LD structured data.
+

--- a/composables/usePageSeo.ts
+++ b/composables/usePageSeo.ts
@@ -1,9 +1,29 @@
-import { useSeoMeta, useRoute, useRuntimeConfig } from '#imports'
+import {
+  useSeoMeta,
+  useRoute,
+  useRuntimeConfig,
+  useHead,
+  useLocaleHead,
+} from '#imports'
 
-export default function usePageSeo(title: string, description: string) {
+export default function usePageSeo(
+  title: string,
+  description: string,
+  image: string = '/vite.svg',
+) {
   const route = useRoute()
   const config = useRuntimeConfig()
   const baseUrl = config.public.baseUrl || ''
+
+  const { link: i18nLinks } = useLocaleHead({ addSeoAttributes: true })
+
+  useHead({
+    link: [
+      { rel: 'canonical', href: baseUrl + route.fullPath },
+      ...(i18nLinks || []),
+    ],
+    meta: [{ name: 'robots', content: 'index, follow' }],
+  })
 
   useSeoMeta({
     title,
@@ -12,8 +32,10 @@ export default function usePageSeo(title: string, description: string) {
     ogDescription: description,
     ogType: 'website',
     ogUrl: baseUrl + route.fullPath,
+    ogImage: baseUrl + image,
     twitterTitle: title,
     twitterDescription: description,
-    twitterCard: 'summary',
+    twitterCard: 'summary_large_image',
+    twitterImage: baseUrl + image,
   })
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,7 +10,13 @@ export default defineNuxtConfig({
       baseUrl: process.env.NUXT_PUBLIC_BASE_URL || 'http://localhost:3000',
     },
   },
-  modules: ['@pinia/nuxt', '@vite-pwa/nuxt', '@nuxtjs/i18n', 'nuxt-quasar-ui'],
+  modules: [
+    '@pinia/nuxt',
+    '@vite-pwa/nuxt',
+    '@nuxtjs/i18n',
+    'nuxt-quasar-ui',
+    '@nuxtjs/sitemap',
+  ],
   css: [
     'quasar/fonts',
     'quasar/animations',
@@ -101,5 +107,9 @@ export default defineNuxtConfig({
     },
     // 啟用 CSS 變量
     sassVariables: true,
+  },
+
+  sitemap: {
+    siteUrl: process.env.NUXT_PUBLIC_BASE_URL || 'http://localhost:3000',
   },
 })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -56,11 +56,27 @@
 
 <script setup>
 import usePageSeo from '~/composables/usePageSeo'
+import { useHead, useRuntimeConfig } from '#imports'
 
 usePageSeo(
   '首頁 - DogFriend 專業看護媒合平台',
   '快速找到可靠看護，了解我們的服務與優勢',
 )
+// JSON-LD structured data for organization
+const config = useRuntimeConfig()
+useHead({
+  script: [
+    {
+      type: 'application/ld+json',
+      children: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Organization',
+        name: 'DogFriend',
+        url: config.public.baseUrl,
+      }),
+    },
+  ],
+})
 // home page
 </script>
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml


### PR DESCRIPTION
## Summary
- default Open Graph image uses existing vite.svg
- remove PWA icon placeholders and unused og image
- document SEO features in README
- keep canonical, hreflang and robots meta handling

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*
- `npm run lint:style` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_68712466a30c8325bfcb8ec4911f4f24