### PR TITLE
Improve SEO with automatic breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ This project uses ESLint, Prettier and Stylelint to keep the code style consiste
 
 The project now includes canonical and hreflang links, robots.txt, and automatic sitemap generation. The home page also provides basic JSON-LD structured data.
 
+### Additional SEO Features
+
+- A global `BreadcrumbList` JSON-LD is injected on every page for better indexing.
+- The **services** page outputs a `BreadcrumbList` and multiple `Service` objects in JSON-LD so that search engines better understand available care options.
+- The **about** and **contact** pages include dedicated JSON-LD descriptions.
+- Images use native lazy-loading to improve performance and Core Web Vitals.
+

--- a/composables/usePageSeo.ts
+++ b/composables/usePageSeo.ts
@@ -23,6 +23,29 @@ export default function usePageSeo(
       ...(i18nLinks || []),
     ],
     meta: [{ name: 'robots', content: 'index, follow' }],
+    script: [
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            {
+              '@type': 'ListItem',
+              position: 1,
+              name: '首頁',
+              item: baseUrl + '/',
+            },
+            {
+              '@type': 'ListItem',
+              position: 2,
+              name: title,
+              item: baseUrl + route.fullPath,
+            },
+          ],
+        }),
+      },
+    ],
   })
 
   useSeoMeta({

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -49,11 +49,30 @@
 
 <script setup>
 import usePageSeo from '~/composables/usePageSeo'
+import { useRuntimeConfig, useRoute, useHead } from '#imports'
 
 usePageSeo(
   '關於我們 - DogFriend 專業看護媒合平台',
   '認識 DogFriend 團隊與我們的使命',
 )
+
+const route = useRoute()
+const config = useRuntimeConfig()
+const baseUrl = config.public.baseUrl || ''
+useHead({
+  script: [
+    {
+      type: 'application/ld+json',
+      children: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'AboutPage',
+        name: '關於我們 - DogFriend',
+        url: baseUrl + route.fullPath,
+        description: '認識 DogFriend 團隊與我們的使命',
+      }),
+    },
+  ],
+})
 const missions = [
   {
     title: '以人為本',

--- a/pages/app.vue
+++ b/pages/app.vue
@@ -8,6 +8,7 @@
           class="qr-code q-my-md"
           src="https://api.qrserver.com/v1/create-qr-code/?data=https://www.example.com/app&size=150x150"
           alt="App QR Code"
+          loading="lazy"
         />
         <div class="row justify-center q-gutter-sm">
           <q-btn flat color="primary" label="App Store" />

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -49,9 +49,28 @@
 
 <script setup>
 import usePageSeo from '~/composables/usePageSeo'
+import { useRuntimeConfig, useRoute, useHead } from '#imports'
+import { ref } from 'vue'
 
 usePageSeo('聯繫我們 - DogFriend', '歡迎透過電話或 Email 與我們聯絡')
-import { ref } from 'vue'
+
+const route = useRoute()
+const config = useRuntimeConfig()
+const baseUrl = config.public.baseUrl || ''
+useHead({
+  script: [
+    {
+      type: 'application/ld+json',
+      children: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'ContactPage',
+        name: '聯繫我們 - DogFriend',
+        url: baseUrl + route.fullPath,
+        description: '歡迎透過電話或 Email 與我們聯絡',
+      }),
+    },
+  ],
+})
 
 const name = ref('')
 const email = ref('')

--- a/pages/services.vue
+++ b/pages/services.vue
@@ -28,7 +28,46 @@
 </template>
 
 <script setup>
+import { useRuntimeConfig, useRoute, useHead } from '#imports'
 import usePageSeo from '~/composables/usePageSeo'
 
 usePageSeo('服務介紹 - DogFriend', '瞭解居家與醫院看護等多元服務項目')
+
+const route = useRoute()
+const config = useRuntimeConfig()
+const baseUrl = config.public.baseUrl || ''
+
+useHead({
+  script: [
+    {
+      type: 'application/ld+json',
+      children: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'Service',
+            serviceType: '居家照顧',
+            description: '提供到府日常照料與生活協助',
+            provider: { '@type': 'Organization', name: 'DogFriend', url: baseUrl },
+            areaServed: 'Taiwan',
+          },
+          {
+            '@type': 'Service',
+            serviceType: '醫院看護',
+            description: '協助住院期間的照護需求',
+            provider: { '@type': 'Organization', name: 'DogFriend', url: baseUrl },
+            areaServed: 'Taiwan',
+          },
+          {
+            '@type': 'Service',
+            serviceType: '外籍看護',
+            description: '多語溝通、跨文化照護',
+            provider: { '@type': 'Organization', name: 'DogFriend', url: baseUrl },
+            areaServed: 'Taiwan',
+          },
+        ],
+      }),
+    },
+  ],
+})
 </script>


### PR DESCRIPTION
## Summary
- inject BreadcrumbList structured data through `usePageSeo`
- add JSON-LD details to the about and contact pages
- keep structured data on the services page focused on service info
- document the new SEO enhancements

## Testing
- `npm run lint` *(fails: couldn't find eslint.config.js)*
- `npm run lint:style` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_b_6871339927c48325b8978b141548bb21